### PR TITLE
Doc: add preprocess example and other extension settings to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,96 @@ Provides syntax highlighting and rich intellisense for Svelte components in VS C
 
 ### Settings
 
-#### `svelte.language-server.runtime`
+##### `svelte.language-server.runtime`
 
 Path to the node executable you would like to use to run the language server.
 This is useful when you depend on native modules such as node-sass as without
 this they will run in the context of vscode, meaning v8 version mismatch is likely.
 
-#### Other
+##### `svelte.plugin.typescript.enable`
 
-Check out the settings editor in vs code to configure / disable any feature provided.
+Enable the TypeScript plugin. _Default_: `true`
+
+##### `svelte.plugin.typescript.diagnostics`
+
+Enable diagnostic messages for TypeScript. _Default_: `true`
+
+##### `svelte.plugin.typescript.hover`
+
+Enable hover info for TypeScript. _Default_: `true`
+
+##### `svelte.plugin.typescript.documentSymbols`
+
+Enable document symbols for TypeScript. _Default_: `true`
+
+##### `svelte.plugin.typescript.completions`
+
+Enable completions for TypeScript. _Default_: `true`
+
+##### `svelte.plugin.typescript.definitions`
+
+Enable go to definition for TypeScript. _Default_: `true`
+
+##### `svelte.plugin.typescript.codeActions`
+
+Enable code actions for TypeScript. _Default_: `true`
+
+##### `svelte.plugin.css.enable`
+
+Enable the CSS plugin. _Default_: `true`
+
+##### `svelte.plugin.css.diagnostics`
+
+Enable diagnostic messages for CSS. _Default_: `true`
+
+##### `svelte.plugin.css.hover`
+
+Enable hover info for CSS. _Default_: `true`
+
+##### `svelte.plugin.css.completions`
+
+Enable auto completions for CSS. _Default_: `true`
+
+##### `svelte.plugin.css.documentColors`
+
+Enable document colors for CSS. _Default_: `true`
+
+##### `svelte.plugin.css.colorPresentations`
+
+Enable color picker for CSS. _Default_: `true`
+
+##### `svelte.plugin.css.documentSymbols`
+
+Enable document symbols for CSS. _Default_: `true`
+
+##### `svelte.plugin.html.enable`
+
+Enable the HTML plugin. _Default_: `true`
+
+##### `svelte.plugin.html.hover`
+
+Enable hover info for HTML. _Default_: `true`
+
+##### `svelte.plugin.html.completions`
+
+Enable auto completions for HTML. _Default_: `true`
+
+##### `svelte.plugin.html.tagComplete`
+
+Enable HTML tag auto closing. _Default_: `true`
+
+##### `svelte.plugin.html.documentSymbols`
+
+Enable document symbols for HTML. _Default_: `true`
+
+##### `svelte.plugin.svelte.enable`
+
+Enable the Svelte plugin. _Default_: `true`
+
+##### `svelte.plugin.svelte.diagnostics.enable`
+
+Enable diagnostic messages for Svelte. _Default_: `true`
+
+##### `svelte.plugin.svelte.format.enable`
+
+Enable formatting for Svelte (includes css & js). _Default_: `true`

--- a/README.md
+++ b/README.md
@@ -30,6 +30,36 @@ Provides syntax highlighting and rich intellisense for Svelte components in VS C
     -   Go to definition
     -   Code Actions
 
+### Using with preprocessors
+
+If a svelte file contains some language other than `html`, `css` or `javascript`, `svelte-vscode` needs to know how to [preprocess](https://svelte.dev/docs#svelte_preprocess) it. This can be achieved by creating a `svelte.config.js` file at the root of your project which exports a svelte options object (similar to `svelte-loader` and `rollup-plugin-svelte`).
+
+```js
+// svelte.config.js
+const preprocess = require('my-example-svelte-preprocessor');
+
+module.exports = {
+    preprocess: [preprocess()],
+    // ...other svelte options
+};
+```
+
+It's also necessary to add a `type="text/language-name"` or `lang="language-name"` to your `style` and `script` tags, which defines how that code should be interpreted by the extension.
+
+```html
+<div>
+    <h1>Hello, world!</h1>
+</div>
+
+<style type="text/scss">
+    div {
+        h1 {
+            color: red;
+        }
+    }
+</style>
+```
+
 ### Settings
 
 ##### `svelte.language-server.runtime`


### PR DESCRIPTION
An attempt document other extension options than `svelte.language-server.runtime` and to guide some people on how to configure the extension to interpret svelte files that should be preprocessed.

Possibly related to #79, #64, #77, #28, #46, #30